### PR TITLE
Fixed bug with vim-tmux-navigator

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -1,5 +1,5 @@
-require 'core.options' -- Load general options
-require 'core.keymaps' -- Load general keymaps
+require 'core.options'  -- Load general options
+require 'core.keymaps'  -- Load general keymaps
 require 'core.snippets' -- Custom code snippets
 
 -- Install package manager
@@ -49,6 +49,7 @@ require('lazy').setup({
   require 'plugins.avante',
   require 'plugins.chatgpt',
   require 'plugins.aerial',
+  require 'plugins.vim-tmux-navigator',
 }, {
   ui = {
     -- If you have a Nerd Font, set icons to an empty table which will use the

--- a/nvim/lua/plugins/misc.lua
+++ b/nvim/lua/plugins/misc.lua
@@ -1,8 +1,21 @@
 -- Standalone plugins with less than 10 lines of config go here
 return {
   {
-    -- tmux & split window navigation
     'christoomey/vim-tmux-navigator',
+    cmd = {
+      'TmuxNavigateLeft',
+      'TmuxNavigateDown',
+      'TmuxNavigateUp',
+      'TmuxNavigateRight',
+      'TmuxNavigatePrevious',
+    },
+    keys = {
+      { '<c-h>', '<cmd><C-U>TmuxNavigateLeft<cr>' },
+      { '<c-j>', '<cmd><C-U>TmuxNavigateDown<cr>' },
+      { '<c-k>', '<cmd><C-U>TmuxNavigateUp<cr>' },
+      { '<c-l>', '<cmd><C-U>TmuxNavigateRight<cr>' },
+      { '<c-\\>', '<cmd><C-U>TmuxNavigatePrevious<cr>' },
+    },
   },
   {
     -- autoclose tags

--- a/nvim/lua/plugins/misc.lua
+++ b/nvim/lua/plugins/misc.lua
@@ -1,23 +1,6 @@
 -- Standalone plugins with less than 10 lines of config go here
 return {
   {
-    'christoomey/vim-tmux-navigator',
-    cmd = {
-      'TmuxNavigateLeft',
-      'TmuxNavigateDown',
-      'TmuxNavigateUp',
-      'TmuxNavigateRight',
-      'TmuxNavigatePrevious',
-    },
-    keys = {
-      { '<c-h>', '<cmd><C-U>TmuxNavigateLeft<cr>' },
-      { '<c-j>', '<cmd><C-U>TmuxNavigateDown<cr>' },
-      { '<c-k>', '<cmd><C-U>TmuxNavigateUp<cr>' },
-      { '<c-l>', '<cmd><C-U>TmuxNavigateRight<cr>' },
-      { '<c-\\>', '<cmd><C-U>TmuxNavigatePrevious<cr>' },
-    },
-  },
-  {
     -- autoclose tags
     'windwp/nvim-ts-autotag',
   },

--- a/nvim/lua/plugins/vim-tmux-navigator.lua
+++ b/nvim/lua/plugins/vim-tmux-navigator.lua
@@ -1,0 +1,17 @@
+return {
+  'christoomey/vim-tmux-navigator',
+  cmd = {
+    'TmuxNavigateLeft',
+    'TmuxNavigateDown',
+    'TmuxNavigateUp',
+    'TmuxNavigateRight',
+    'TmuxNavigatePrevious',
+  },
+  keys = {
+    { '<c-h>',  '<cmd><C-U>TmuxNavigateLeft<cr>' },
+    { '<c-j>',  '<cmd><C-U>TmuxNavigateDown<cr>' },
+    { '<c-k>',  '<cmd><C-U>TmuxNavigateUp<cr>' },
+    { '<c-l>',  '<cmd><C-U>TmuxNavigateRight<cr>' },
+    { '<c-\\>', '<cmd><C-U>TmuxNavigatePrevious<cr>' },
+  },
+}

--- a/nvim/lua/plugins/vim-tmux-navigator.lua
+++ b/nvim/lua/plugins/vim-tmux-navigator.lua
@@ -1,3 +1,4 @@
+-- Copied config from https://github.com/christoomey/vim-tmux-navigator
 return {
   'christoomey/vim-tmux-navigator',
   cmd = {
@@ -8,10 +9,10 @@ return {
     'TmuxNavigatePrevious',
   },
   keys = {
-    { '<c-h>',  '<cmd><C-U>TmuxNavigateLeft<cr>' },
-    { '<c-j>',  '<cmd><C-U>TmuxNavigateDown<cr>' },
-    { '<c-k>',  '<cmd><C-U>TmuxNavigateUp<cr>' },
-    { '<c-l>',  '<cmd><C-U>TmuxNavigateRight<cr>' },
+    { '<c-h>', '<cmd><C-U>TmuxNavigateLeft<cr>' },
+    { '<c-j>', '<cmd><C-U>TmuxNavigateDown<cr>' },
+    { '<c-k>', '<cmd><C-U>TmuxNavigateUp<cr>' },
+    { '<c-l>', '<cmd><C-U>TmuxNavigateRight<cr>' },
     { '<c-\\>', '<cmd><C-U>TmuxNavigatePrevious<cr>' },
   },
 }


### PR DESCRIPTION
I had a bug where Control+motion (where motion is one of h,j,k,l) would completely freeze neovim. I tracked this down to missing configuration options in the vim-tmux-navigator. Adding the recommended config (from https://github.com/christoomey/vim-tmux-navigator) immediately fixed the bug for me. 

I also took the liberty of moving this plugin out of miscellaneous to a separate file, in order not to clutter misc.lua.