### PR TITLE
fix(zsh): Fixes redirect logs from tmux.

### DIFF
--- a/zsh/custom.zsh
+++ b/zsh/custom.zsh
@@ -66,7 +66,7 @@ if which tmux >/dev/null 2>&1; then
         -z "$VIM" && \
         -z "$INTELLIJ_ENVIRONMENT_READER" ]]; then
     # Try to attach to the default tmux session, or create a new one if it doesn't exist
-    tmux attach -t default || tmux new -s default
+    tmux attach -t default >/dev/null 2>&1 || tmux new -s default
     exit
   fi
 fi


### PR DESCRIPTION
I come here following your youtube article on configuring tmux. When `zsh` starts a default session on `tmux`, there is a log line 'no session' that flashes.  

Log message appears out of `tmux attach -t default` when there is no active session by the name `default`.  

Fixed by redirecting the log message to `/dev/null` since the intention is not to parse the log message. 

Thanks for your good work on yt. 👍🏼 